### PR TITLE
By default boundscheck the index upon construction

### DIFF
--- a/src/IndirectArrays.jl
+++ b/src/IndirectArrays.jl
@@ -12,7 +12,16 @@ values[index[i,j]]`.
 immutable IndirectArray{T,N} <: AbstractArray{T,N}
     index::Array{Int,N}
     values::Vector{T}
+
+    @inline function IndirectArray(index, values)
+        # The typical logic for testing bounds and then using
+        # @inbounds will not check whether index is inbounds for
+        # values. So we had better check this on construction.
+        @boundscheck checkbounds(values, index)
+        new(index, values)
+    end
 end
+Base.@propagate_inbounds IndirectArray{T,N}(index::Array{Int,N},values::Vector{T}) = IndirectArray{T,N}(index,values)
 
 Base.size(A::IndirectArray) = size(A.index)
 Base.linearindexing(A::IndirectArray) = Base.LinearFast()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,3 +13,15 @@ A = IndirectArray(index, colors)
 @test A[1,2] === A[3] === RGB(0,1,0)
 @test A[2,2] === A[4] === RGB(1,0,0)
 @test isa(eachindex(A), AbstractUnitRange)
+
+# Bounds checking upon construction
+index_ob = copy(index)
+index_ob[1] = 5   # out-of-bounds
+unsafe_ia(idx, vals) = (@inbounds ret = IndirectArray(idx, vals); ret)
+  safe_ia(idx, vals) = (ret = IndirectArray(idx, vals); ret)
+@test_throws BoundsError safe_ia(index_ob, colors)
+# This requires inlining, which means it fails on Travis since we turn
+# off inlining for better coverage stats
+# B = unsafe_ia(index_ob, colors)
+# @test_throws BoundsError B[1]
+# @test B[2] == RGB(0,0,1)


### PR DESCRIPTION
When algorithms perform size-checks to decide whether they can use `@inbounds`, those checks won't catch situations in which the index is out-of-bounds for the `values` array. If we want to be able to eliminate that boundscheck in `getindex`, we'd better check the bounds on construction. Fortunately, one can eliminate this check in cases where you know it's safe by using `@inbounds` for construction. (This doesn't seem to work outside a function, however.)
