### PR TITLE
Remove ambiguous constructors

### DIFF
--- a/src/IndirectArrays.jl
+++ b/src/IndirectArrays.jl
@@ -27,12 +27,12 @@ struct IndirectArray{T,N,A<:AbstractArray{<:Integer,N},V<:AbstractVector{T}} <: 
 end
 Base.@propagate_inbounds IndirectArray(index::AbstractArray{<:Integer,N}, values::AbstractVector{T}) where {T,N} =
     IndirectArray{T,N,typeof(index),typeof(values)}(index, values)
-
-function (::Type{IndirectArray{T}})(A::AbstractArray, values::AbstractVector = unique(A)) where {T}
+function (::Type{IndirectArray{T}})(A::AbstractArray) where {T}
+    values = unique(A)
     index = convert(Array{T}, indexin(A, values))
     return IndirectArray(index, values)
 end
-IndirectArray(A::AbstractArray, values::AbstractVector = unique(A)) = IndirectArray{UInt8}(A, values)
+IndirectArray(A::AbstractArray) = IndirectArray{UInt8}(A)
 
 Base.size(A::IndirectArray) = size(A.index)
 Base.indices(A::IndirectArray) = indices(A.index)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ xc = copy(x)
 @test x == xc
 xc[2], xc[3] = RGB(0,1,0), RGB(0,1,1)
 @test xc == IndirectArray([RGB(1,0,0), RGB(0,1,0), RGB(0,1,1), RGB(1,0,0)])
-@test append!(x, x)                           == IndirectArray([colors[:]; colors[:]])
+@test append!(x, x) == IndirectArray([colors[:]; colors[:]])
 @test append!(x, IndirectArray([RGB(1,0,0), RGB(1,1,0)])) ==
     IndirectArray([colors[:]; colors[:]; [RGB(1,0,0), RGB(1,1,0)]])
 
@@ -40,7 +40,7 @@ unsafe_ia(idx, vals) = (@inbounds ret = IndirectArray(idx, vals); ret)
 # @test B[2] == RGB(0,0,1)
 
 # Non-Arrays
-a = [0.1 0.4;
+a = [0.1  0.4;
      0.33 1.0]
 f(x) = round(Int, 99*x) + 1   # maps 0-1 to 1-100
 m = mappedarray(f, a)


### PR DESCRIPTION
The old and new versions should be equivalent but the new test fails with the current version. I think that https://github.com/JuliaArrays/IndirectArrays.jl/blob/3f9fc132eab83fe631ea36d19aa345bdb39ef573/src/IndirectArrays.jl#L28-L29 is somehow getting called with the current version.